### PR TITLE
Betere rpad voor unicode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@solely/simple-fm": "^1.7.2",
         "discord.js": "^14.15.3",
         "dotenv": "^16.4.5",
+        "grapheme-splitter": "^1.0.4",
         "sqlite3": "^5.1.7",
         "zod": "^3.23.8"
       },
@@ -2413,6 +2414,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "license": "MIT"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@solely/simple-fm": "^1.7.2",
     "discord.js": "^14.15.3",
     "dotenv": "^16.4.5",
+    "grapheme-splitter": "^1.0.4",
     "sqlite3": "^5.1.7",
     "zod": "^3.23.8"
   }

--- a/src/commands/fipo.ts
+++ b/src/commands/fipo.ts
@@ -1,6 +1,7 @@
 import type { Message } from "discord.js";
 import { registerCommand } from "../commandHandler.js";
 import db from "../db.js";
+import GraphemeSplitter from "grapheme-splitter";
 
 let todaysFipos: Message<boolean>[] = [];
 let recordedDate = "0-0-000";
@@ -137,11 +138,20 @@ registerCommand({
         return Math.max(acc, row.name.length);
       }, 0);
 
+      const splitter = new GraphemeSplitter();
+      const rpad = (str: string, length: number, pad: string) => {
+        const graphemes = splitter.splitGraphemes(str);
+        while (graphemes.length < length) {
+          graphemes.push(pad);
+        }
+        return graphemes.join('');
+      };
+
       message.reply({
         allowedMentions: { repliedUser: false, users: [], parse: [] },
         content: `# Fipo stats:\n\`\`\`\n${fiposArray
           .map((r) => {
-            return `${r.name.padEnd(longestName + 2)}: ${r.fipos}`;
+            return `${rpad(r.name, longestName + 2, ' ')}: ${r.fipos}`;
           })
           .join("\n")}\n\`\`\``,
       });


### PR DESCRIPTION
Gebruikt import GraphemeSplitter om unicode gedoe te vermijden

Nogsteeds niet perfect, want Discord's monospace is niet monospace, maar iig beter

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FurriousFox/allesbot/pull/1?shareId=d479759f-554c-4496-89c6-427c3d20fa81).